### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/generate-reports-and-analysis.yml
+++ b/.github/workflows/generate-reports-and-analysis.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   report-generation:
     name: Checkout, Build and Run

--- a/.github/workflows/scan-website-csv.yml
+++ b/.github/workflows/scan-website-csv.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   scanning:
     name: Checkout, Build and Run


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to:
  - `.github/workflows/generate-reports-and-analysis.yml`
  - `.github/workflows/scan-website-csv.yml`
- Set `contents: write` because both workflows use `git-auto-commit-action` to write generated updates back to the repository.

## Why
These workflows currently rely on implicit token defaults. Explicit scopes improve least-privilege posture while preserving automated commit behavior.